### PR TITLE
Add detailed layout differences in GameBuildDifferences & Expert Mode Chaos Control Route Control section in SpeedrunTricks

### DIFF
--- a/docs/GettingStarted/SpeedrunTricks.md
+++ b/docs/GettingStarted/SpeedrunTricks.md
@@ -34,3 +34,16 @@ This is legal in the current rules for IL attempts, but the runner must include 
 When playing on some consoles, the game can have a bit of time after using Chaos Control or moving very fast between sections where the enemies are not ready in memory and will need more time before appearing in the world.  When this occurs, the player can pause the game and unpause shortly after to help give the game more time to load in the missing content.  
 
 This is helpful for runs that focus on the In Game Timer, or runs where doing this helps with the real time needed to continue.
+
+## Chaos Control Route/Spline Control in Expert Mode
+The mission/partner currently selected affects which spline Shadow takes when using Chaos Control. In Expert Mode, it is still possible to set this flag in the pause menu.
+
+1. Pause the game
+2. Press "down", highlighting "restart"
+3. Press "right", setting the 'hero' flag
+You'll know it worked because the "restart" will move back up to "resume" with no noise
+4. Press "A" (or equivalent for non-GameCube, not the Start or pause/unpause button!)
+
+Doing the same but for "left" would set the 'dark' flag
+
+Further details can be found [here](ExpertCCRouteControl)

--- a/docs/GettingStarted/SpeedrunTricks/ExpertCCRouteControl.md
+++ b/docs/GettingStarted/SpeedrunTricks/ExpertCCRouteControl.md
@@ -1,0 +1,27 @@
+#Expert Chaos Control Route Control
+
+If you are not aware, different Chaos Control paths/branches/splines can sometimes be taken depending on which partner you have out.
+
+For example, Glyphic Canyon takes the full circular route at checkpoint #5 if Black Doom is out. 
+It skips it if Knuckles or No Partner is out.
+Seen here:
+![type:video](https://www.youtube.com/embed/UQkjTtP7yvI)
+
+This brings us to Space Gadget, which allows us to take the Dark Route or Hero Route depending on which partner we have out. Initially it was thought Expert mode disables the mission byte flags. Specific positioning was used to get the correct CC branch in Expert mode to get to the faster route in Space Gadget.
+
+However I found only the D-Pad mission flags were disabled. You can set the mission flags in the pause menu.
+This is because the pause menu code is the same as normal mode, only the images are different.
+
+Thus we can set ourselves to instantly take the Hero spline in Space Gadget Expert:
+
+1. Pause the game
+2. Press "down", highlighting "restart" 
+3. Press "right", setting the 'hero' flag
+You'll know it worked because the "restart" will move back up to "resume" with no noise
+
+4. Press "A" (or equivalent for non-GameCube, not the Start or pause/unpause button!)
+
+This video shows the default behavior and after setting the 'hero' mission flag:
+![type:video](https://www.youtube.com/embed/CzB57zg_BiQ)
+
+This trick also results in some expert stages having regular partner dialog if you perform this early. Notably Digital Circuit has lots of left over voice lines from Normal Mode lingering in Expert Mode if you enable the mission flag.

--- a/docs/Misc/GameBuildDifferences.md
+++ b/docs/Misc/GameBuildDifferences.md
@@ -33,3 +33,34 @@ While not always the case with games, there are a handful of differences between
 
 For example, the versions build on Oct 16th and later have the powerful Chaos Control Glitch patched. Making the US GameCube and PS2 versions the only ones that can perform that glitch.
 
+The Oct 16th and later versions also have a few minor level object (layout) differences, extra objects are added as documented below.
+
+### Oct 16th Layout Changes
+
+|Stage & Type|Change|Layout File|
+|--|--|--|
+Glyphic Canyon (All)|Extra Killplane Collision (6) on Secret KeyDoor route|stg0201/stg0201_cmn.dat|
+Cryptic Castle (Expert)|ChaosControlStop Trigger at Chao Room / Dark route|stg0300/stg0300_hrd.dat|
+The Doom (All)|Bugfix/GUN Robot (170) sets RenderDist 7 -> 5 to prevent it falling through floor, *possibly also "Unknown" as well|stg0401/stg0401_cmn.dat|
+Mad Matrix (Normal)|Unknown|stg0403/stg0403_nrm.dat|
+Air Fleet (All)|Unknown|stg0501/stg0501_cmn.dat|
+Air Fleet (Expert)|ChaosControlStop Trigger x2 for blocked door / routes on Expert|stg0501/stg0501_hrd.dat|
+Iron Jungle (Expert)|ChaosControlStop Trigger at RailSplit / Dark upper route|stg0502/stg0502_hrd.dat|
+Lost Impact (All)|9 Extra Objects, 7 are SolidCollision Triggers, 1 Extra GUN Beetle and GUN Soldier at Checkpoint 8|stg0504/stg0504_cmn.dat|
+GUN Fortress (All)|Unknown|stg0600/stg0600_cmn.dat|
+GUN Fortress (Expert)|Two ChaosControlStop Triggers on upward Hero route areas|stg0600/stg0600_hrd.dat|
+Lava Shelter (Expert)|ChaosControlStop Trigger on Hero route|stg0602/stg0602_hrd.dat|
+Final Haunt (Destructibles)|Unknown. Note: Both have a Black Oak (Giant) which is abnormal for .ds1 files|stg0604/stg0604_ds1.dat|
+Final Haunt (Expert)|4x Duplicate Black Oak (x2 on Oak # 1, x2 on Oak # 3), x3 Platform Duplicate, x3 ChaosControlStop Triggers at Dark Route Flying Sections|stg0604/stg0604_hrd.dat|
+
+The most significant changes are Final Haunt (Expert), The Doom (All), and Lost Impact (All).
+
+**Final Haunt** contains duplicates of objects found in the cmn layout, in the hrd (expert mode) layout. There are 4 extra Black Oaks stacked into their original object and 3 extra platforms stacked into original objects. Likely these duplicate objects were a copy/paste mistake while the ChaosControlStop Triggers were added.
+
+**The Doom** lowers the render distance of the GUN Robot with LinkID 170, located right after the 6th checkpoint in the proceeding elevator room. This is a significant change as pre-Oct 16 builds of the game have to warp away with the checkpoint and back again to get this robot to spawn for the mission The Doom Dark.
+
+**Lost Impact** adds extra SolidCollisions to the ceiling of some rooms, preventing out of bounds ceiling jumps via spindash jump- none of which are currently used in runs anyway. Additionally, there is an extra GUN Beetle and GUN Soldier at the 8th checkpoint.
+
+**Other stage changes** consistent primarily of adding in ChaosControlStop Triggers that act as quick bugfixes. These prevent players from going the wrong way in Expert Mode while using Chaos Control. Ex: Cryptic Castle Dark route instead of Normal route while in Expert Mode.
+
+**Unknown** changes mean the object counts are identical across versions, but there is a checksum difference. Likely an object was tweaked: position, rotation, object parameters (which weapon an enemy holds, how they behave, etc). Alternatively, it is possible an object was swapped out entirely for another object (ex Metal box for Wood box). These specifics are not determined, it is only known the count is the same but there is a mismatch regardless.

--- a/docs/SiteContributors.md
+++ b/docs/SiteContributors.md
@@ -5,6 +5,9 @@ Below are the list of individuals that helped contribute data / info to the site
 ## BlazinZzetti
 Site Owner, Site Editor, and pretty much anything not listed by others.
 
+## dreamsyntax
+Provided info on speedrun tricks and technical game info.
+
 ## CFood
 Provided a handful of images for the Shadow Boxes.
 


### PR DESCRIPTION
* appends partner detail to Chaos Control Extension section
* adds Chaos Control Route/Spline Control in Expert Mode section in SpeedrunTricks
* adds detailed Oct 16th build layout (object) differences to GameBuildDifferences